### PR TITLE
subclassing dict rather than collections.abc.Mapping

### DIFF
--- a/ev/config.py
+++ b/ev/config.py
@@ -21,6 +21,12 @@ from collections import Mapping
 import json
 import os
 
+# Python 2/3 compatibility
+try:
+  basestring
+except NameError:
+  basestring = str
+
 def _merge_dicts(d1, d2):
   """
   Modifies d1 in-place to contain values from d2.  If any value
@@ -65,15 +71,12 @@ class Config(dict):
     single JSON object.
 
     """
-    if kwargs or (len(files)==1 and type(files[0]) is not str):
+    if kwargs or (len(files) == 1 and not isinstance(files[0], basestring):
       return dict.__init__(self, *files, **kwargs)
+
     dict.__init__(self) # init with an empty dictionary
     for f in files:
       _merge_dicts(self, _load_file(f))
-
-  # Python2 compatibility
-  def __unicode__(self):
-    return unicode(self)
 
 _configs = {}
 def get_config(env = None, public_file = None, private_file = None):

--- a/ev/config.py
+++ b/ev/config.py
@@ -53,34 +53,27 @@ def _load_file(f):
   with codecs.open(f, mode = 'r', encoding = 'utf-8') as in_stream:
     return json.load(in_stream)
 
-class Config(Mapping):
+class Config(dict):
 
   """A mapping class which represents a (json-based) mapping of configuration objects."""
 
-  def __init__(self, *files):
-    """Loads each provided file in turn, merging it (and overriding keys) from
-    the previously loaded file. The files are expected to be utf-8 encoded JSON
-    files.
+  def __init__(self, *files, **kwargs):
+    """If provided with a dictionary or named arguments, populates itself from that
+    information.  Otherwise assumes a list of filenames, and loads each provided
+    file in turn, merging it (and overriding keys) from the previously loaded
+    file. The files are expected to be utf-8 encoded JSON files, each with a
+    single JSON object.
 
     """
-    self._data = _load_file(files[0])
-    for f in files[1:]:
-      _merge_dicts(self._data, _load_file(f))
+    if kwargs or (len(files)==1 and type(files[0]) is not str):
+      return dict.__init__(self, *files, **kwargs)
+    dict.__init__(self) # init with an empty dictionary
+    for f in files:
+      _merge_dicts(self, _load_file(f))
 
-  def __getitem__(self, key):
-    return self._data[key]
-
-  def __iter__(self):
-    return iter(self._data)
-
-  def __len__(self):
-    return len(self._data)
-
-  def __str__(self):
-    return str(self._data)
-
+  # Python2 compatibility
   def __unicode__(self):
-    return unicode(self._data)
+    return unicode(self)
 
 _configs = {}
 def get_config(env = None, public_file = None, private_file = None):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
   name = 'ev',
-  version = '0.0.1',
+  version = '0.0.2',
   description = 'Elephant Ventures Libraries',
   url = 'https://github.com/ElephantVentures/ev_python_lib',
   author = 'Elephant Ventures',


### PR DESCRIPTION
Rather than create a Mapping that acts like a dict, we can just use a dict.

I also hacked `__init__` a bit so that Config can be initialized either with (1) a dict, named arguments, or a list of tuples like a dict can, or (2) a single or multiple positional arguments of strings that are filenames.

I tested this with `Config(a='apple',b='banana',c='cherry')`, `Config({'a':'apple','b':'banana','c':'cherry'})`, `Config('bob.json')` where bob.json is `{"a": "apple", "b": "banana"}`, and `Config('bob.json','alice.json')` where alice.json is `{"y":"yes","n":"no","c":"cherry","a":"alligator"}`.
